### PR TITLE
Remove "localhost" only

### DIFF
--- a/gradio_server.py
+++ b/gradio_server.py
@@ -553,7 +553,6 @@ if __name__ == "__main__":
         server_port = int(os.getenv("SERVER_PORT", "7860"))
 
     server_name = args.server_name
-    server_name = "localhost"
     if len(server_name) == 0:
         server_name = os.getenv("SERVER_NAME", "0.0.0.0")
 


### PR DESCRIPTION
The server name was fixed to "localhost" and could not be changed. The subsequent `if` statement was always `False`.